### PR TITLE
Add minimal TypeScript MARC models

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,19 @@
+# MarcTools TypeScript
+
+This directory contains a minimal TypeScript implementation of data models for MARC21 records inspired by the original C# code in this repository.  It exposes classes you can import into your own TypeScript or JavaScript projects.
+
+```
+npm install
+npm run build
+```
+
+Usage example:
+
+```ts
+import { MarcRecord, MarcField } from 'marc-tools-ts';
+
+const record = new MarcRecord();
+const field = new MarcField('245', '10');
+field.addSubfield('a', 'Example title');
+record.addField(field);
+```

--- a/typescript/dist/index.d.ts
+++ b/typescript/dist/index.d.ts
@@ -1,0 +1,3 @@
+export { MarcSubfield } from './marcSubfield';
+export { MarcField } from './marcField';
+export { MarcRecord } from './marcRecord';

--- a/typescript/dist/index.js
+++ b/typescript/dist/index.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MarcRecord = exports.MarcField = exports.MarcSubfield = void 0;
+var marcSubfield_1 = require("./marcSubfield");
+Object.defineProperty(exports, "MarcSubfield", { enumerable: true, get: function () { return marcSubfield_1.MarcSubfield; } });
+var marcField_1 = require("./marcField");
+Object.defineProperty(exports, "MarcField", { enumerable: true, get: function () { return marcField_1.MarcField; } });
+var marcRecord_1 = require("./marcRecord");
+Object.defineProperty(exports, "MarcRecord", { enumerable: true, get: function () { return marcRecord_1.MarcRecord; } });

--- a/typescript/dist/marcField.d.ts
+++ b/typescript/dist/marcField.d.ts
@@ -1,0 +1,8 @@
+import { MarcSubfield } from './marcSubfield';
+export declare class MarcField {
+    tag: string;
+    indicators: string;
+    subfields: MarcSubfield[];
+    constructor(tag: string, indicators?: string);
+    addSubfield(code: string, value: string): void;
+}

--- a/typescript/dist/marcField.js
+++ b/typescript/dist/marcField.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MarcField = void 0;
+const marcSubfield_1 = require("./marcSubfield");
+class MarcField {
+    constructor(tag, indicators = '  ') {
+        this.tag = tag;
+        this.indicators = indicators;
+        this.subfields = [];
+    }
+    addSubfield(code, value) {
+        this.subfields.push(new marcSubfield_1.MarcSubfield(code, value));
+    }
+}
+exports.MarcField = MarcField;

--- a/typescript/dist/marcRecord.d.ts
+++ b/typescript/dist/marcRecord.d.ts
@@ -1,0 +1,11 @@
+import { MarcField } from './marcField';
+/**
+ * Represents a MARC21 record following basic Library of Congress specs.
+ */
+export declare class MarcRecord {
+    leader: string;
+    private fields;
+    addField(field: MarcField): void;
+    /** Returns all fields in tag order */
+    get sortedFields(): MarcField[];
+}

--- a/typescript/dist/marcRecord.js
+++ b/typescript/dist/marcRecord.js
@@ -1,0 +1,20 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MarcRecord = void 0;
+/**
+ * Represents a MARC21 record following basic Library of Congress specs.
+ */
+class MarcRecord {
+    constructor() {
+        this.leader = '00000nam  2200000 a 4500';
+        this.fields = [];
+    }
+    addField(field) {
+        this.fields.push(field);
+    }
+    /** Returns all fields in tag order */
+    get sortedFields() {
+        return this.fields.slice().sort((a, b) => a.tag.localeCompare(b.tag));
+    }
+}
+exports.MarcRecord = MarcRecord;

--- a/typescript/dist/marcSubfield.d.ts
+++ b/typescript/dist/marcSubfield.d.ts
@@ -1,0 +1,5 @@
+export declare class MarcSubfield {
+    code: string;
+    value: string;
+    constructor(code: string, value: string);
+}

--- a/typescript/dist/marcSubfield.js
+++ b/typescript/dist/marcSubfield.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MarcSubfield = void 0;
+class MarcSubfield {
+    constructor(code, value) {
+        this.code = code;
+        this.value = value;
+    }
+}
+exports.MarcSubfield = MarcSubfield;

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "marc-tools-ts",
+  "version": "0.1.0",
+  "description": "TypeScript utilities for MARC21 records based on LoC specs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,3 @@
+export { MarcSubfield } from './marcSubfield';
+export { MarcField } from './marcField';
+export { MarcRecord } from './marcRecord';

--- a/typescript/src/marcField.ts
+++ b/typescript/src/marcField.ts
@@ -1,0 +1,14 @@
+import { MarcSubfield } from './marcSubfield';
+
+export class MarcField {
+  public subfields: MarcSubfield[] = [];
+
+  constructor(
+    public tag: string,
+    public indicators: string = '  '
+  ) {}
+
+  addSubfield(code: string, value: string) {
+    this.subfields.push(new MarcSubfield(code, value));
+  }
+}

--- a/typescript/src/marcRecord.ts
+++ b/typescript/src/marcRecord.ts
@@ -1,0 +1,18 @@
+import { MarcField } from './marcField';
+
+/**
+ * Represents a MARC21 record following basic Library of Congress specs.
+ */
+export class MarcRecord {
+  public leader: string = '00000nam  2200000 a 4500';
+  private fields: MarcField[] = [];
+
+  addField(field: MarcField) {
+    this.fields.push(field);
+  }
+
+  /** Returns all fields in tag order */
+  get sortedFields(): MarcField[] {
+    return this.fields.slice().sort((a, b) => a.tag.localeCompare(b.tag));
+  }
+}

--- a/typescript/src/marcSubfield.ts
+++ b/typescript/src/marcSubfield.ts
@@ -1,0 +1,3 @@
+export class MarcSubfield {
+  constructor(public code: string, public value: string) {}
+}

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a `typescript` directory with a simple MARC record model
- include build config and compiled output
- document how to use the new module

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68472e1c7b2483308f0f6d2864a08b0f